### PR TITLE
add `doc` in browser/__init__.py

### DIFF
--- a/browser/__init__.py
+++ b/browser/__init__.py
@@ -89,7 +89,7 @@ class _mockbrython(dict):
 
 
 document = _mockbrython()
-
+doc = _mockbrython()
 
 def alert(*args, **kwargs):
     pass


### PR DESCRIPTION
Thank you for developing this project.
By the way, I personally prefer to use `from browser import doc` in Brython.
This change will support this usage.